### PR TITLE
Prevent logger from being pickled

### DIFF
--- a/imblearn/base.py
+++ b/imblearn/base.py
@@ -225,3 +225,9 @@ class SamplerMixin(six.with_metaclass(ABCMeta, BaseEstimator)):
             The corresponding label of `X_resampled`
         """
         pass
+
+    def __getstate__(self):
+        """Prevent logger from being pickled"""
+        object_dictionary = dict(self.__dict__)
+        del object_dictionary['logger']
+        return object_dictionary


### PR DESCRIPTION
I think that there is no need to pickle the logger. So, to prevent the logger from being pickled I implemented the **getstate** method in the SamplerMixin. Although, I don't know if this is the right way.
