### PR TITLE
Get logger in fit and sample using private method

### DIFF
--- a/imblearn/base.py
+++ b/imblearn/base.py
@@ -47,7 +47,7 @@ class SamplerMixin(six.with_metaclass(ABCMeta, BaseEstimator)):
         """
 
         self.ratio = ratio
-        self.logger = logging.getLogger(__name__)
+        
 
     def fit(self, X, y):
         """Find the classes statistics before to perform sampling.
@@ -69,6 +69,8 @@ class SamplerMixin(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         # Check the consistency of X and y
         X, y = check_X_y(X, y)
+		
+        self._get_logger()
 
         self.min_c_ = None
         self.maj_c_ = None
@@ -138,6 +140,8 @@ class SamplerMixin(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         # Check the consistency of X and y
         X, y = check_X_y(X, y)
+		
+        self._get_logger()
 
         # Check that the data have been fitted
         if not hasattr(self, 'stats_c_'):
@@ -220,3 +224,7 @@ class SamplerMixin(six.with_metaclass(ABCMeta, BaseEstimator)):
         object_dictionary = self.__dict__.copy()
         del object_dictionary['logger']
         return object_dictionary
+
+		
+    def _get_logger(self):
+        self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
If you pickle and then unpickle the sampler then there is no logger in the object because we discarded it in the `__getstate__` method. So, if you try to call the `sample` method after unpickling the sampler you get `AttributeError: 'EditedNearestNeighbours' object has no attribute 'logger'`

This PR solves this problem by adding a private method to get the logger.
